### PR TITLE
fix timezone issue,

### DIFF
--- a/chronos.js
+++ b/chronos.js
@@ -23,6 +23,7 @@ var inputDescription = jQuery(document).find('#inputDescription');
 var buttonClose = jQuery(document).find('#buttonClose');
 var buttonSave = jQuery(document).find('#buttonSave');
 var buttonDelete = jQuery(document).find('#buttonDelete');
+var _currentDate = new Date();
 
 selectEmployee.change(changeEmployee);
 buttonPrevious.click(previousDate);
@@ -160,12 +161,13 @@ function setDate(current) {
             (month < 10 ? "0" + month : month) + "-" +
             (day < 10 ? "0" + day : day));
     date.text(current.toLocaleDateString());
+    _currentDate = current;
     fillLines();
     setWorks();
 }
 
 function currentDate() {
-    return new Date(date.attr('datetime'));
+    return _currentDate;
 }
 
 function previousDate() {


### PR DESCRIPTION
When in a negative GMT timezone(e.g. GMT-3) prev button jumps by two days and forward button doesn't work, this is because the code is using the displayed date instead of a saved date object. When displayed the date converts to localtime. By creating a new Date object from the displayed time every time we need to change it we are substracting it 3 hours and thats causing it to change to the day before.